### PR TITLE
Endpoint for clearing chat

### DIFF
--- a/api/controllers/ChatController.js
+++ b/api/controllers/ChatController.js
@@ -23,6 +23,18 @@ module.exports = {
             Chat.watch(req.socket);
             console.log("New User Subscribed to: " + req.socket.id);
         }
+    },
+
+    /**
+     * Clear Chat api
+     * In production this should be wrapped with a permission check
+     * via policies. Also even though this demo doesn't have them
+     * All of these endpoints should be covered with Unit tests.
+     */
+    clearChat: function(req, res) {
+        Chat.destroy().exec((err, chats) => {
+            res.json(chats);
+        })
     }
 };
 


### PR DESCRIPTION
Doesn't publish the destroy as this is a debug only feature, but in the future we could add a publish remove and make it so individuals can delete their own chats.